### PR TITLE
Overlap of the bin symlink with the Osprey

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "preferGlobal": "true",
   "bin": {
-    "osprey": "dist/osprey-cli.js"
+    "osprey-cli": "dist/osprey-cli.js"
   },
   "files": [
     "dist"


### PR DESCRIPTION
Hi guys
First of all, thanks for this!

However it's annoying to don't be able to use the `node_modules/.bin/osprey`, because if you require both Osprey and Osprey-Cli, one will overwrite the other:
- https://github.com/mulesoft/osprey/blob/master/package.json#L13
- https://github.com/mulesoft/osprey-cli/blob/master/package.json#L58

So what I come to ask is to change the alias to the repo name
